### PR TITLE
Additions to the `correct_merging` branch

### DIFF
--- a/node_lib.py
+++ b/node_lib.py
@@ -37,16 +37,16 @@ class Placeholder(Node):
 
     def derivate(self, symbol) :
         if self.symbol == symbol :
-            return Scalar(1)
+            return Scalar([1])
         else :
-            return Scalar(0)
+            return Scalar([0])
 
     def get_placeholder(self) :
         return set([self])
 
 class Scalar(Node) :
     def __init__(self, value) :
-        self.value = value
+        self.value = value[0]
         self.update_symbol()
 
     def update_symbol(self) :
@@ -57,15 +57,15 @@ class Scalar(Node) :
         return self.value
 
     def derivate(self, symbol) :
-        return Scalar(0)
+        return Scalar([0])
 
     def get_placeholder(self) :
         return set()
 
 class Operator(Node) :
-    def __init__(self, input1, input2) :
-        self.input1 = input1
-        self.input2 = input2
+    def __init__(self, input) :
+        self.input1 = input[0]
+        self.input2 = input[1]
         self.update_symbol()
 
     def get_placeholder(self) :
@@ -73,7 +73,7 @@ class Operator(Node) :
 
 class Function(Node) :
     def __init__(self, input) :
-        self.input = input
+        self.input = input[0]
         self.update_symbol()
 
     def get_placeholder(self) :
@@ -88,7 +88,7 @@ class Sommator(Operator):
         return self.input1.compute(**feed_dict) + self.input2.compute(**feed_dict)
 
     def derivate(self, symbol) :
-        return Sommator(self.input1.derivate(symbol), self.input2.derivate(symbol))
+        return Sommator([self.input1.derivate(symbol), self.input2.derivate(symbol)])
 
 
 class Substractor(Operator):
@@ -100,7 +100,7 @@ class Substractor(Operator):
         return self.input1.compute(**feed_dict) - self.input2.compute(**feed_dict)
 
     def derivate(self, symbol) :
-        return Substractor(self.input1.derivate(symbol), self.input2.derivate(symbol))
+        return Substractor([self.input1.derivate(symbol), self.input2.derivate(symbol)])
 
 class Multiplicator(Operator) :
     def update_symbol(self) :
@@ -111,7 +111,7 @@ class Multiplicator(Operator) :
         return self.input1.compute(**feed_dict) * self.input2.compute(**feed_dict)
 
     def derivate(self, symbol) :
-        return Sommator(Multiplicator(self.input1.derivate(symbol), self.input2), Multiplicator(self.input1, self.input2.derivate(symbol)))
+        return Sommator([Multiplicator([self.input1.derivate(symbol), self.input2]), Multiplicator([self.input1, self.input2.derivate(symbol)])])
 
 class Divisor(Operator) :
     def update_symbol(self) :
@@ -122,7 +122,7 @@ class Divisor(Operator) :
         return self.input1.compute(**feed_dict) / self.input2.compute(**feed_dict)
 
     def derivate(self, symbol) :
-        return Divisor(Substractor(Multiplicator(self.input1.derivate(symbol), self.input2), Multiplicator(self.input1, self.input2.derivate(symbol))), Power(self.input2, Scalar(2)))
+        return Divisor([Substractor([Multiplicator([self.input1.derivate(symbol), self.input2]), Multiplicator([self.input1, self.input2.derivate(symbol)])]), Power([self.input2, Scalar([2])])])
 
 
 class Power(Operator) :
@@ -134,16 +134,16 @@ class Power(Operator) :
         return self.input1.compute(**feed_dict) ** self.input2.compute(**feed_dict)
 
     def derivate(self, symbol) :
-        return Multiplicator(Power(self.input1, self.input2), Sommator(Multiplicator(self.input1.derivate(symbol), Divisor(self.input2, self.input1)), Multiplicator(self.input2.derivate(symbol), LogarithmNeperien(self.input1))))
+        return Multiplicator([Power([self.input1, self.input2]), Sommator([Multiplicator([self.input1.derivate(symbol), Divisor([self.input2, self.input1])]), Multiplicator([self.input2.derivate(symbol), LogarithmNeperien([self.input1])])])])
 
 
 class Logarithm(Node) :
-    def __init__(self, input, base = None) :
-        self.input = input
-        if not base:
-            self.base = Scalar(np.e)
+    def __init__(self, input) :
+        self.input = input[0]
+        if len(input) < 2 :
+            self.base = Scalar([np.e])
         else :
-            self.base = base
+            self.base = input[1]
         self.update_symbol()
 
     def update_symbol(self) :
@@ -159,7 +159,7 @@ class Logarithm(Node) :
             return np.nan
 
     def derivate(self, symbol) :
-        return Divisor(LogarithmNeperien(self.input), LogarithmNeperien(self.base)).derivate(symbol)
+        return Divisor([LogarithmNeperien([self.input]), LogarithmNeperien([self.base])]).derivate(symbol)
 
     def get_placeholder(self) :
         return self.input.get_placeholder() | self.base.get_placeholder()
@@ -170,7 +170,7 @@ class LogarithmNeperien(Logarithm) :
         return self.symbol
 
     def derivate(self, symbol) :
-        return Divisor(self.input.derivate(symbol), self.input)
+        return Divisor([self.input.derivate(symbol), self.input])
 
 class Cos(Function) :
     def update_symbol(self) :
@@ -181,7 +181,7 @@ class Cos(Function) :
         return np.cos(self.input.compute(**feed_dict))
 
     def derivate(self, symbol) :
-        return Multiplicator(Multiplicator(Scalar(-1), Sin(self.input)), self.input.derivate(symbol))
+        return Multiplicator([Multiplicator([Scalar([-1]), Sin([self.input])]), self.input.derivate(symbol)])
 
 class Sin(Function) :
     def update_symbol(self) :
@@ -192,7 +192,7 @@ class Sin(Function) :
         return np.sin(self.input.compute(**feed_dict))
 
     def derivate(self, symbol) :
-        return Multiplicator(Cos(self.input), self.input.derivate(symbol))
+        return Multiplicator([Cos([self.input]), self.input.derivate(symbol)])
 
 class Tan(Function) :
     def update_symbol(self) :
@@ -203,12 +203,12 @@ class Tan(Function) :
         return np.tan(self.input.compute(**feed_dict))
 
     def derivate(self, symbol) :
-        return Divisor(Sin(self.input), Cos(self.input)).derivate(symbol)
+        return Divisor([Sin([self.input]), Cos([self.input])]).derivate(symbol)
 
 
 if __name__ == '__main__' :
 
-    f1 = Logarithm(Placeholder('x'), Placeholder('u'))
+    f1 = Logarithm([Placeholder('x'), Placeholder('u')])
 
     feed_dict = {'x':2, 'u':0.2}
 

--- a/node_lib.py
+++ b/node_lib.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 class Node :

--- a/node_lib.py
+++ b/node_lib.py
@@ -33,7 +33,7 @@ class Placeholder(Node):
         try :
             return feed_dict[self.symbol]
         except :
-            raise 'YAY'
+            raise 'Error: %s not given in the list of symbols.' % self.symbol
 
     def derivate(self, symbol) :
         if self.symbol == symbol :

--- a/node_lib.py
+++ b/node_lib.py
@@ -7,7 +7,7 @@ class Node :
     def update_symbol(self) :
         raise NotImplementedError
 
-    def compute(self, **feed_dict) :
+    def compute(self, feed_dict) :
         raise NotImplementedError
 
     def derivate(self) :
@@ -29,7 +29,7 @@ class Placeholder(Node):
     def update_symbol(self) :
         return self.symbol
 
-    def compute(self, **feed_dict) :
+    def compute(self, feed_dict) :
         try :
             return feed_dict[self.symbol]
         except :
@@ -53,7 +53,7 @@ class Scalar(Node) :
         self.symbol = '(' + str(self.value) + ')'
         return self.symbol
 
-    def compute(self, **feed_dict) :
+    def compute(self, feed_dict) :
         return self.value
 
     def derivate(self, symbol) :
@@ -84,8 +84,8 @@ class Sommator(Operator):
         self.symbol = '(' + self.input1.update_symbol() + "+" + self.input2.update_symbol() + ')'
         return self.symbol
 
-    def compute(self, **feed_dict) :
-        return self.input1.compute(**feed_dict) + self.input2.compute(**feed_dict)
+    def compute(self, feed_dict) :
+        return self.input1.compute(feed_dict) + self.input2.compute(feed_dict)
 
     def derivate(self, symbol) :
         return Sommator([self.input1.derivate(symbol), self.input2.derivate(symbol)])
@@ -96,8 +96,8 @@ class Substractor(Operator):
         self.symbol = '(' + self.input1.update_symbol() + "-" + self.input2.update_symbol() + ')'
         return self.symbol
 
-    def compute(self, **feed_dict) :
-        return self.input1.compute(**feed_dict) - self.input2.compute(**feed_dict)
+    def compute(self, feed_dict) :
+        return self.input1.compute(feed_dict) - self.input2.compute(feed_dict)
 
     def derivate(self, symbol) :
         return Substractor([self.input1.derivate(symbol), self.input2.derivate(symbol)])
@@ -107,8 +107,8 @@ class Multiplicator(Operator) :
         self.symbol = '(' + self.input1.update_symbol() + "*" + self.input2.update_symbol() + ')'
         return self.symbol
 
-    def compute(self, **feed_dict) :
-        return self.input1.compute(**feed_dict) * self.input2.compute(**feed_dict)
+    def compute(self, feed_dict) :
+        return self.input1.compute(feed_dict) * self.input2.compute(feed_dict)
 
     def derivate(self, symbol) :
         return Sommator([Multiplicator([self.input1.derivate(symbol), self.input2]), Multiplicator([self.input1, self.input2.derivate(symbol)])])
@@ -118,8 +118,8 @@ class Divisor(Operator) :
         self.symbol = '(' + self.input1.update_symbol() + "/" + self.input2.update_symbol() + ')'
         return self.symbol
 
-    def compute(self, **feed_dict) :
-        return self.input1.compute(**feed_dict) / self.input2.compute(**feed_dict)
+    def compute(self, feed_dict) :
+        return self.input1.compute(feed_dict) / self.input2.compute(feed_dict)
 
     def derivate(self, symbol) :
         return Divisor([Substractor([Multiplicator([self.input1.derivate(symbol), self.input2]), Multiplicator([self.input1, self.input2.derivate(symbol)])]), Power([self.input2, Scalar([2])])])
@@ -130,8 +130,8 @@ class Power(Operator) :
         self.symbol = '(' + self.input1.update_symbol() + "^" + self.input2.update_symbol() + ')'
         return self.symbol
 
-    def compute(self, **feed_dict) :
-        return self.input1.compute(**feed_dict) ** self.input2.compute(**feed_dict)
+    def compute(self, feed_dict) :
+        return self.input1.compute(feed_dict) ** self.input2.compute(feed_dict)
 
     def derivate(self, symbol) :
         return Multiplicator([Power([self.input1, self.input2]), Sommator([Multiplicator([self.input1.derivate(symbol), Divisor([self.input2, self.input1])]), Multiplicator([self.input2.derivate(symbol), LogarithmNeperien([self.input1])])])])
@@ -150,9 +150,9 @@ class Logarithm(Node) :
         self.symbol = '(log[' + self.base.update_symbol() + '](' + self.input.update_symbol() + '))'
         return self.symbol
 
-    def compute(self, **feed_dict) :
-        arg_value = self.input.compute(**feed_dict)
-        base_value = self.base.compute(**feed_dict)
+    def compute(self, feed_dict) :
+        arg_value = self.input.compute(feed_dict)
+        base_value = self.base.compute(feed_dict)
         if arg_value > 0 and base_value > 0 and base_value != 1 :
             return np.log(arg_value) / np.log(base_value)
         else :
@@ -177,8 +177,8 @@ class Cos(Function) :
         self.symbol = '(cos(' + self.input.update_symbol() + '))'
         return self.symbol
 
-    def compute(self, **feed_dict) :
-        return np.cos(self.input.compute(**feed_dict))
+    def compute(self, feed_dict) :
+        return np.cos(self.input.compute(feed_dict))
 
     def derivate(self, symbol) :
         return Multiplicator([Multiplicator([Scalar([-1]), Sin([self.input])]), self.input.derivate(symbol)])
@@ -188,8 +188,8 @@ class Sin(Function) :
         self.symbol = '(sin(' + self.input.update_symbol() + '))'
         return self.symbol
 
-    def compute(self, **feed_dict) :
-        return np.sin(self.input.compute(**feed_dict))
+    def compute(self, feed_dict) :
+        return np.sin(self.input.compute(feed_dict))
 
     def derivate(self, symbol) :
         return Multiplicator([Cos([self.input]), self.input.derivate(symbol)])
@@ -199,8 +199,8 @@ class Tan(Function) :
         self.symbol = '(tan(' + self.input.update_symbol() + '))'
         return self.symbol
 
-    def compute(self, **feed_dict) :
-        return np.tan(self.input.compute(**feed_dict))
+    def compute(self, feed_dict) :
+        return np.tan(self.input.compute(feed_dict))
 
     def derivate(self, symbol) :
         return Divisor([Sin([self.input]), Cos([self.input])]).derivate(symbol)
@@ -213,9 +213,9 @@ if __name__ == '__main__' :
     feed_dict = {'x':2, 'u':0.2}
 
     print(f1.update_symbol())
-    print(f1.compute(**feed_dict))
+    print(f1.compute(feed_dict))
     print(f1.derivate('u').update_symbol())
-    print(f1.derivate('u').compute(**feed_dict))
+    print(f1.derivate('u').compute(feed_dict))
 
     for i in f1.get_placeholder() :
         print(i.symbol)

--- a/node_lib.py
+++ b/node_lib.py
@@ -8,7 +8,7 @@ class Node :
     def update_symbol(self) :
         raise NotImplementedError
 
-    def compute(self, feed_dict) :
+    def compute(self, **feed_dict) :
         raise NotImplementedError
 
     def derivate(self) :
@@ -30,7 +30,7 @@ class Placeholder(Node):
     def update_symbol(self) :
         return self.symbol
 
-    def compute(self, feed_dict) :
+    def compute(self, **feed_dict) :
         try :
             return feed_dict[self.symbol]
         except :
@@ -54,7 +54,7 @@ class Scalar(Node) :
         self.symbol = '(' + str(self.value) + ')'
         return self.symbol
 
-    def compute(self, feed_dict) :
+    def compute(self, **feed_dict) :
         return self.value
 
     def derivate(self, symbol) :
@@ -85,8 +85,8 @@ class Sommator(Operator):
         self.symbol = '(' + self.input1.update_symbol() + "+" + self.input2.update_symbol() + ')'
         return self.symbol
 
-    def compute(self, feed_dict) :
-        return self.input1.compute(feed_dict) + self.input2.compute(feed_dict)
+    def compute(self, **feed_dict) :
+        return self.input1.compute(**feed_dict) + self.input2.compute(**feed_dict)
 
     def derivate(self, symbol) :
         return Sommator([self.input1.derivate(symbol), self.input2.derivate(symbol)])
@@ -97,8 +97,8 @@ class Substractor(Operator):
         self.symbol = '(' + self.input1.update_symbol() + "-" + self.input2.update_symbol() + ')'
         return self.symbol
 
-    def compute(self, feed_dict) :
-        return self.input1.compute(feed_dict) - self.input2.compute(feed_dict)
+    def compute(self, **feed_dict) :
+        return self.input1.compute(**feed_dict) - self.input2.compute(**feed_dict)
 
     def derivate(self, symbol) :
         return Substractor([self.input1.derivate(symbol), self.input2.derivate(symbol)])
@@ -108,8 +108,8 @@ class Multiplicator(Operator) :
         self.symbol = '(' + self.input1.update_symbol() + "*" + self.input2.update_symbol() + ')'
         return self.symbol
 
-    def compute(self, feed_dict) :
-        return self.input1.compute(feed_dict) * self.input2.compute(feed_dict)
+    def compute(self, **feed_dict) :
+        return self.input1.compute(**feed_dict) * self.input2.compute(**feed_dict)
 
     def derivate(self, symbol) :
         return Sommator([Multiplicator([self.input1.derivate(symbol), self.input2]), Multiplicator([self.input1, self.input2.derivate(symbol)])])
@@ -119,8 +119,8 @@ class Divisor(Operator) :
         self.symbol = '(' + self.input1.update_symbol() + "/" + self.input2.update_symbol() + ')'
         return self.symbol
 
-    def compute(self, feed_dict) :
-        return self.input1.compute(feed_dict) / self.input2.compute(feed_dict)
+    def compute(self, **feed_dict) :
+        return self.input1.compute(**feed_dict) / self.input2.compute(**feed_dict)
 
     def derivate(self, symbol) :
         return Divisor([Substractor([Multiplicator([self.input1.derivate(symbol), self.input2]), Multiplicator([self.input1, self.input2.derivate(symbol)])]), Power([self.input2, Scalar([2])])])
@@ -131,8 +131,8 @@ class Power(Operator) :
         self.symbol = '(' + self.input1.update_symbol() + "^" + self.input2.update_symbol() + ')'
         return self.symbol
 
-    def compute(self, feed_dict) :
-        return self.input1.compute(feed_dict) ** self.input2.compute(feed_dict)
+    def compute(self, **feed_dict) :
+        return self.input1.compute(**feed_dict) ** self.input2.compute(**feed_dict)
 
     def derivate(self, symbol) :
         return Multiplicator([Power([self.input1, self.input2]), Sommator([Multiplicator([self.input1.derivate(symbol), Divisor([self.input2, self.input1])]), Multiplicator([self.input2.derivate(symbol), LogarithmNeperien([self.input1])])])])
@@ -151,9 +151,9 @@ class Logarithm(Node) :
         self.symbol = '(log[' + self.base.update_symbol() + '](' + self.input.update_symbol() + '))'
         return self.symbol
 
-    def compute(self, feed_dict) :
-        arg_value = self.input.compute(feed_dict)
-        base_value = self.base.compute(feed_dict)
+    def compute(self, **feed_dict) :
+        arg_value = self.input.compute(**feed_dict)
+        base_value = self.base.compute(**feed_dict)
         if arg_value > 0 and base_value > 0 and base_value != 1 :
             return np.log(arg_value) / np.log(base_value)
         else :
@@ -178,8 +178,8 @@ class Cos(Function) :
         self.symbol = '(cos(' + self.input.update_symbol() + '))'
         return self.symbol
 
-    def compute(self, feed_dict) :
-        return np.cos(self.input.compute(feed_dict))
+    def compute(self, **feed_dict) :
+        return np.cos(self.input.compute(**feed_dict))
 
     def derivate(self, symbol) :
         return Multiplicator([Multiplicator([Scalar([-1]), Sin([self.input])]), self.input.derivate(symbol)])
@@ -189,8 +189,8 @@ class Sin(Function) :
         self.symbol = '(sin(' + self.input.update_symbol() + '))'
         return self.symbol
 
-    def compute(self, feed_dict) :
-        return np.sin(self.input.compute(feed_dict))
+    def compute(self, **feed_dict) :
+        return np.sin(self.input.compute(**feed_dict))
 
     def derivate(self, symbol) :
         return Multiplicator([Cos([self.input]), self.input.derivate(symbol)])
@@ -200,8 +200,8 @@ class Tan(Function) :
         self.symbol = '(tan(' + self.input.update_symbol() + '))'
         return self.symbol
 
-    def compute(self, feed_dict) :
-        return np.tan(self.input.compute(feed_dict))
+    def compute(self, **feed_dict) :
+        return np.tan(self.input.compute(**feed_dict))
 
     def derivate(self, symbol) :
         return Divisor([Sin([self.input]), Cos([self.input])]).derivate(symbol)
@@ -214,9 +214,9 @@ if __name__ == '__main__' :
     feed_dict = {'x':2, 'u':0.2}
 
     print(f1.update_symbol())
-    print(f1.compute(feed_dict))
+    print(f1.compute(**feed_dict))
     print(f1.derivate('u').update_symbol())
-    print(f1.derivate('u').compute(feed_dict))
+    print(f1.derivate('u').compute(**feed_dict))
 
     for i in f1.get_placeholder() :
         print(i.symbol)


### PR DESCRIPTION
This pull request adds multiple things:
- ~The creation of the tree requires no more array (to transform an array `a` into a list of parameter, write `*a`);~ REVERTED by 010fce4 (as requested in private message)
- ~The conversion of the `compute`'s `feed_dict` argument (which is a dictionary) to a list of `key=value` (to transform a dictionary into a list of those, precede it by `**`);~ REVERTED by 9e3de9d (as requested in private message)
- Removes the blank useless first line;
- Changes the `YAY` error when you try to `compute` without giving a value into something more useful.